### PR TITLE
pmdb/23854: Updated documentation link in info.json

### DIFF
--- a/widget/info.json
+++ b/widget/info.json
@@ -17,7 +17,7 @@
             "https:\/\/repo.fortisoar.fortinet.com\/fsr-widgets\/incidentCorrelations-2.1.0\/images\/incident-correlations.png"
         ],
         "description": "<p>Incident Correlations<\/p> <ul> <li>Correlation graph of given incident <li>Displays all the correlated records in a graph format for the given incident<\/li> <li>Requires Following<\/li> <ul> <li>Incident ID through input<\/li> <\/ul> <\/ul>",
-        "help_online": "https:\/\/github.com\/fortinet-fortisoar\/widget-incident-correlations\/blob\/release\/2.1.0\/docs\/README.md",
+        "help_online": "https:\/\/github.com\/fortinet-fortisoar\/widget-incident-correlations\/blob\/release\/2.1.0\/README.md",
         "compatibility": [
             "7.0.2",
             "7.2.2",


### PR DESCRIPTION
As per new documentation structure, README.md is outside docs directory. Updated path in info.json file.